### PR TITLE
fix(keyboard): Normalize meta/os key names

### DIFF
--- a/testing/juggler/content/PageAgent.js
+++ b/testing/juggler/content/PageAgent.js
@@ -491,6 +491,10 @@ class PageAgent {
   async dispatchKeyEvent({type, keyCode, code, key, repeat, location}) {
     const frame = this._frameTree.mainFrame();
     const tip = frame.textInputProcessor();
+    if (key === 'Meta' && Services.appinfo.OS !== 'Darwin')
+      key = 'OS';
+    else if (key === 'OS' && Services.appinfo.OS === 'Darwin')
+      key = 'Meta';
     let keyEvent = new (frame.domWindow().KeyboardEvent)("", {
       key,
       code,


### PR DESCRIPTION
Firefox calls the meta key "OS" on all platforms except for mac, where it is "Meta"